### PR TITLE
Fix a bug that if no Content-Length included in response header

### DIFF
--- a/library/src/main/java/com/danikula/videocache/ProxyCache.java
+++ b/library/src/main/java/com/danikula/videocache/ProxyCache.java
@@ -153,7 +153,8 @@ class ProxyCache {
 
     private void tryComplete() throws ProxyCacheException {
         synchronized (stopLock) {
-            if (!isStopped() && cache.available() == source.length()) {
+            long sourceLength = source.length();
+            if (!isStopped() && (cache.available() == sourceLength || sourceLength == -1)) {
                 cache.complete();
             }
         }


### PR DESCRIPTION
This bug will cause the cache file never completed.